### PR TITLE
Implement resizable grid layout

### DIFF
--- a/src/components/Screen.vue
+++ b/src/components/Screen.vue
@@ -1,11 +1,8 @@
 <template>
-  <div class="min-h-screen bg-gray-900 grid" :class="showFeaturePanel ? 'grid-cols-[1fr_24rem_24rem]' : 'grid-cols-[1fr_24rem]'">
+  <div class="min-h-screen bg-gray-900 grid" :class="isPlayerCollapsed ? 'grid-cols-[1fr_1.5rem]' : 'grid-cols-[1fr_24rem]'">
     <div class="p-8 overflow-auto min-w-[522px]">
       <div class="flex items-center justify-between">
         <h1 class="text-3xl font-bold text-purple-400 mb-8">MJ Screen Jukebox</h1>
-        <button @click="toggleFeaturePanel" class="text-sm text-purple-300 hover:underline ml-4">
-          {{ showFeaturePanel ? 'Masquer' : 'Afficher' }} le panneau
-        </button>
       </div>
 
       <div>
@@ -13,13 +10,13 @@
       </div>
     </div>
 
-    <div class="w-96 bg-gray-800 p-6 flex flex-col justify-start border-l border-gray-700">
+    <div v-if="!isPlayerCollapsed" class="relative w-96 bg-gray-800 p-6 flex flex-col justify-start border-l border-gray-700">
+      <button @click="togglePlayer" class="absolute right-2 top-2 text-purple-300 hover:text-purple-400">&gt;</button>
       <TracksPlayer ref="tracksPlayer" />
     </div>
 
-    <div v-if="showFeaturePanel" class="w-96 bg-gray-700 p-6 flex flex-col justify-start border-l border-gray-700">
-      <p class="text-purple-300 font-semibold mb-2">Nouveau panneau</p>
-      <p class="text-gray-300">Placez ici votre future fonctionnalité.</p>
+    <div v-else class="flex items-start border-l border-gray-700 relative">
+      <button @click="togglePlayer" class="text-purple-300 hover:text-purple-400 m-2">&lt;</button>
     </div>
   </div>
 </template>
@@ -41,13 +38,13 @@
       const library = ref<InstanceType<typeof Library> | null>(null);
       const tracksPlayer = ref<InstanceType<typeof TracksPlayer> | null>(null);
 
-      const showFeaturePanel = ref(Cookies.get('showFeaturePanel') !== 'false');
-      watch(showFeaturePanel, val => {
-        Cookies.set('showFeaturePanel', val ? 'true' : 'false');
+      const isPlayerCollapsed = ref(Cookies.get('playerCollapsed') === 'true');
+      watch(isPlayerCollapsed, val => {
+        Cookies.set('playerCollapsed', val ? 'true' : 'false');
       });
 
-      function toggleFeaturePanel() {
-        showFeaturePanel.value = !showFeaturePanel.value;
+      function togglePlayer() {
+        isPlayerCollapsed.value = !isPlayerCollapsed.value;
       }
 
       const handlePlay = (track: FileTrack, volume: number) => {
@@ -60,8 +57,8 @@
         library,
         tracksPlayer,
         handlePlay,
-        showFeaturePanel,
-        toggleFeaturePanel,
+        isPlayerCollapsed,
+        togglePlayer,
       };
     },
   });

--- a/src/components/Screen.vue
+++ b/src/components/Screen.vue
@@ -10,21 +10,18 @@
       </div>
     </div>
 
-    <div v-if="!isPlayerCollapsed" class="relative w-96 bg-gray-800 p-6 flex flex-col justify-start border-l border-gray-700">
-      <button
-        @click="togglePlayer"
-        class="absolute right-2 top-2 rounded-full p-1 text-purple-300 hover:text-purple-400 hover:bg-gray-600/40 transition-colors"
-      >
+    <div v-if="!isPlayerCollapsed" class="w-96 bg-gray-800 p-6 flex flex-col justify-start border-l border-gray-700 relative">
+      <button @click="togglePlayer"
+              class="absolute -left-3 top-2 rounded-full p-1 text-purple-300 hover:text-purple-400 hover:bg-gray-700 transition-colors bg-gray-800 border border-gray-600 shadow-md">
         <ChevronRight class="w-4 h-4" />
       </button>
+
       <TracksPlayer ref="tracksPlayer" />
     </div>
 
-    <div v-else class="flex items-center justify-center border-l border-gray-700">
-      <button
-        @click="togglePlayer"
-        class="rounded-full p-1 text-purple-300 hover:text-purple-400 hover:bg-gray-600/40 transition-colors"
-      >
+    <div v-else class="relative w-6 flex items-center justify-center border-l border-gray-700">
+      <button @click="togglePlayer"
+              class="absolute -left-3 top-2 rounded-full p-1 text-purple-300 hover:text-purple-400 hover:bg-gray-700 transition-colors bg-gray-800 border border-gray-600 shadow-md">
         <ChevronLeft class="w-4 h-4" />
       </button>
     </div>

--- a/src/components/Screen.vue
+++ b/src/components/Screen.vue
@@ -1,24 +1,35 @@
 <template>
-  <div className="min-h-screen bg-gray-900 flex">
-    <div className="flex-1 p-8 overflow-auto mr-96 min-w-[522px]">
-      <h1 className="text-3xl font-bold text-purple-400 mb-8">MJ Screen Jukebox</h1>
+  <div class="min-h-screen bg-gray-900 grid" :class="showFeaturePanel ? 'grid-cols-[1fr_24rem_24rem]' : 'grid-cols-[1fr_24rem]'">
+    <div class="p-8 overflow-auto min-w-[522px]">
+      <div class="flex items-center justify-between">
+        <h1 class="text-3xl font-bold text-purple-400 mb-8">MJ Screen Jukebox</h1>
+        <button @click="toggleFeaturePanel" class="text-sm text-purple-300 hover:underline ml-4">
+          {{ showFeaturePanel ? 'Masquer' : 'Afficher' }} le panneau
+        </button>
+      </div>
 
       <div>
         <Library ref="library" @play="handlePlay" />
       </div>
     </div>
 
-    <div className="w-96 bg-gray-800 p-6 flex flex-col justify-start border-l border-gray-700 fixed right-0 top-0 h-full">
+    <div class="w-96 bg-gray-800 p-6 flex flex-col justify-start border-l border-gray-700">
       <TracksPlayer ref="tracksPlayer" />
+    </div>
+
+    <div v-if="showFeaturePanel" class="w-96 bg-gray-700 p-6 flex flex-col justify-start border-l border-gray-700">
+      <p class="text-purple-300 font-semibold mb-2">Nouveau panneau</p>
+      <p class="text-gray-300">Placez ici votre future fonctionnalité.</p>
     </div>
   </div>
 </template>
 
 <script lang="ts">
-  import { defineComponent, ref } from 'vue';
+  import { defineComponent, ref, watch } from 'vue';
   import Library from './Library.vue';
   import TracksPlayer from './TracksPlayer.vue';
   import FileTrack from '../models/FileTrack'
+  import { Cookies } from '../models/Cookies';
 
   export default defineComponent({
     name: 'Screen',
@@ -30,9 +41,18 @@
       const library = ref<InstanceType<typeof Library> | null>(null);
       const tracksPlayer = ref<InstanceType<typeof TracksPlayer> | null>(null);
 
+      const showFeaturePanel = ref(Cookies.get('showFeaturePanel') !== 'false');
+      watch(showFeaturePanel, val => {
+        Cookies.set('showFeaturePanel', val ? 'true' : 'false');
+      });
+
+      function toggleFeaturePanel() {
+        showFeaturePanel.value = !showFeaturePanel.value;
+      }
+
       const handlePlay = (track: FileTrack, volume: number) => {
         if (tracksPlayer.value) {
-          tracksPlayer.value.addTrack(track.file, track.name, track.initialVolume); // Passe les données au composant TracksPlayer
+          tracksPlayer.value.addTrack(track.file, track.name, track.initialVolume);
         }
       };
 
@@ -40,6 +60,8 @@
         library,
         tracksPlayer,
         handlePlay,
+        showFeaturePanel,
+        toggleFeaturePanel,
       };
     },
   });

--- a/src/components/Screen.vue
+++ b/src/components/Screen.vue
@@ -11,12 +11,22 @@
     </div>
 
     <div v-if="!isPlayerCollapsed" class="relative w-96 bg-gray-800 p-6 flex flex-col justify-start border-l border-gray-700">
-      <button @click="togglePlayer" class="absolute right-2 top-2 text-purple-300 hover:text-purple-400">&gt;</button>
+      <button
+        @click="togglePlayer"
+        class="absolute right-2 top-2 rounded-full p-1 text-purple-300 hover:text-purple-400 hover:bg-gray-600/40 transition-colors"
+      >
+        <ChevronRight class="w-4 h-4" />
+      </button>
       <TracksPlayer ref="tracksPlayer" />
     </div>
 
-    <div v-else class="flex items-start border-l border-gray-700 relative">
-      <button @click="togglePlayer" class="text-purple-300 hover:text-purple-400 m-2">&lt;</button>
+    <div v-else class="flex items-center justify-center border-l border-gray-700">
+      <button
+        @click="togglePlayer"
+        class="rounded-full p-1 text-purple-300 hover:text-purple-400 hover:bg-gray-600/40 transition-colors"
+      >
+        <ChevronLeft class="w-4 h-4" />
+      </button>
     </div>
   </div>
 </template>

--- a/src/components/Uploader.vue
+++ b/src/components/Uploader.vue
@@ -1,12 +1,12 @@
 <template>
-    <label className="w-8 cursor-pointer bg-purple-500 hover:bg-purple-600 px-2 py-1
+    <label class="w-8 cursor-pointer bg-purple-500 hover:bg-purple-600 px-2 py-1
             rounded-lg flex items-center gap-2 transition-colors justify-center">
 
       <Plus/>
       <input type="file"
               accept="audio/*"
               @change="handleFileChange"
-              className="hidden" />
+              class="hidden" />
     </label>
 </template>
 


### PR DESCRIPTION
## Summary
- use grid instead of fixed sidebar in `Screen.vue`
- add toggleable third panel and persist state in cookies
- replace non-standard `className` attributes

## Testing
- `npm run lint` *(fails: Cannot find package 'eslint-plugin-vue')*
- `npm run type-check` *(fails: vue-tsc not found)*

------
https://chatgpt.com/codex/tasks/task_b_68485a4dee5083338006a35f285ad19e