### PR TITLE
Add note panel with track autocompletion

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,8 @@
       "dependencies": {
         "dexie": "^4.0.10",
         "lucide-vue-next": "^0.471.0",
+        "quill": "^2.0.3",
+        "quill-mention": "^6.1.1",
         "svgstore": "^3.0.1",
         "tippy.js": "^6.3.7",
         "vite-svg-loader": "^5.1.0",
@@ -3448,6 +3450,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/eventemitter3": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
+      "license": "MIT"
+    },
     "node_modules/execa": {
       "version": "9.5.2",
       "resolved": "https://registry.npmjs.org/execa/-/execa-9.5.2.tgz",
@@ -3481,6 +3489,12 @@
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/fast-diff": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.3.0.tgz",
+      "integrity": "sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw==",
+      "license": "Apache-2.0"
     },
     "node_modules/fast-glob": {
       "version": "3.3.3",
@@ -4339,6 +4353,25 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/lodash-es": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
+      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.clonedeep": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+      "integrity": "sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==",
+      "deprecated": "This package is deprecated. Use require('node:util').isDeepStrictEqual instead.",
+      "license": "MIT"
+    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
@@ -4771,6 +4804,12 @@
       "dev": true,
       "license": "BlueOak-1.0.0"
     },
+    "node_modules/parchment": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/parchment/-/parchment-3.0.0.tgz",
+      "integrity": "sha512-HUrJFQ/StvgmXRcQ1ftY6VEZUq3jA2t9ncFN4F84J/vN0/FPpQF+8FKXb3l6fLces6q0uOHj6NJn+2xvZnxO6A==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -5139,6 +5178,44 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/quill": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/quill/-/quill-2.0.3.tgz",
+      "integrity": "sha512-xEYQBqfYx/sfb33VJiKnSJp8ehloavImQ2A6564GAbqG55PGw1dAWUn1MUbQB62t0azawUS2CZZhWCjO8gRvTw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "eventemitter3": "^5.0.1",
+        "lodash-es": "^4.17.21",
+        "parchment": "^3.0.0",
+        "quill-delta": "^5.1.0"
+      },
+      "engines": {
+        "npm": ">=8.2.3"
+      }
+    },
+    "node_modules/quill-delta": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/quill-delta/-/quill-delta-5.1.0.tgz",
+      "integrity": "sha512-X74oCeRI4/p0ucjb5Ma8adTXd9Scumz367kkMK5V/IatcX6A0vlgLgKbzXWy5nZmCGeNJm2oQX0d2Eqj+ZIlCA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-diff": "^1.3.0",
+        "lodash.clonedeep": "^4.5.0",
+        "lodash.isequal": "^4.5.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/quill-mention": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/quill-mention/-/quill-mention-6.1.1.tgz",
+      "integrity": "sha512-Ay8lHScPotDa/qSWJry2mxOg8YZxW3UAqlsgwjxXMDwNGv8+g3ydvgpBOq5firdcE+I++tpNTuYubFaNAnejMg==",
+      "license": "MIT",
+      "dependencies": {
+        "quill": "^2.0.2"
+      }
     },
     "node_modules/read-cache": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "dev": "vite",
     "build-icons": "node scripts/build-icon-sprite.mjs",
     "build": "npm run build-icons && run-p type-check \"build-only {@}\" --",
-	"build-no-icons": "run-p type-check \"build-only {@}\" --",
+    "build-no-icons": "run-p type-check \"build-only {@}\" --",
     "preview": "vite preview",
     "build-only": "vite build",
     "type-check": "vue-tsc --build",
@@ -16,6 +16,8 @@
   "dependencies": {
     "dexie": "^4.0.10",
     "lucide-vue-next": "^0.471.0",
+    "quill": "^2.0.3",
+    "quill-mention": "^6.1.1",
     "svgstore": "^3.0.1",
     "tippy.js": "^6.3.7",
     "vite-svg-loader": "^5.1.0",

--- a/src/components/NotesPanel.vue
+++ b/src/components/NotesPanel.vue
@@ -1,0 +1,90 @@
+<template>
+  <div class="w-full bg-gray-800 rounded-lg p-4 mt-4">
+    <h2 class="text-xl font-bold text-purple-300 mb-2">Notes</h2>
+    <div ref="editor" class="bg-white text-black rounded p-2 min-h-[150px]"></div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { onMounted, ref } from 'vue';
+import Quill from 'quill';
+import 'quill/dist/quill.snow.css';
+import 'quill-mention/dist/quill.mention.css';
+import 'quill-mention/autoregister';
+import { DB_GetTracks } from '@/persistance/TrackService';
+import type FileTrack from '@/models/FileTrack';
+
+const emit = defineEmits<{ (e: 'play', track: FileTrack): void }>();
+const editor = ref<HTMLDivElement | null>(null);
+let quill: Quill;
+const tracks = ref<FileTrack[]>([]);
+const trackMap = new Map<string, FileTrack>();
+
+function convertHashesToLinks() {
+  const text = quill.getText();
+  const regex = /#([\w.-]+)/g;
+  let match: RegExpExecArray | null;
+  while ((match = regex.exec(text))) {
+    const index = match.index;
+    const length = match[0].length;
+    const name = match[1];
+    if (trackMap.has(name)) {
+      const delta = quill.getContents(index, length);
+      const hasLink = delta.ops?.some(op => typeof op.insert === 'string' && op.attributes && op.attributes.link);
+      if (!hasLink) {
+        quill.formatText(index, length, 'link', `track:${name}`);
+      }
+    }
+  }
+}
+
+onMounted(async () => {
+  tracks.value = await DB_GetTracks();
+  tracks.value.forEach(t => trackMap.set(t.name, t));
+
+  quill = new Quill(editor.value as HTMLElement, {
+    theme: 'snow',
+    modules: {
+      toolbar: [['bold', 'italic', 'underline', 'strike'], [{ list: 'ordered' }, { list: 'bullet' }], ['clean']],
+      mention: {
+        mentionDenotationChars: ['#'],
+        allowedChars: /^[A-Za-z0-9_ .-]*$/,
+        source: (searchTerm: string, renderList: (values: {id: string, value: string}[], searchTerm: string) => void) => {
+          const values = tracks.value.map(t => ({ id: t.name, value: t.name }));
+          if (!searchTerm) {
+            renderList(values, searchTerm);
+          } else {
+            const matches = values.filter(v => v.value.toLowerCase().includes(searchTerm.toLowerCase()));
+            renderList(matches, searchTerm);
+          }
+        },
+        onSelect: (item: DOMStringMap, insertItem: (data: Record<string, unknown>) => void) => {
+          insertItem(item);
+          const range = quill.getSelection(true);
+          if (range) {
+            quill.formatText(range.index - item.value.length - 1, item.value.length + 1, 'link', `track:${item.value}`);
+          }
+        },
+      },
+    },
+  });
+
+  editor.value!.addEventListener('click', e => {
+    const target = e.target as HTMLElement;
+    if (target.tagName === 'A' && target.getAttribute('href')?.startsWith('track:')) {
+      e.preventDefault();
+      const name = target.getAttribute('href')!.slice('track:'.length);
+      const track = trackMap.get(name);
+      if (track) emit('play', track);
+    }
+  });
+
+  editor.value!.addEventListener('paste', () => {
+    setTimeout(convertHashesToLinks, 0);
+  });
+
+  quill.on('text-change', (delta, old, source) => {
+    if (source === 'user') convertHashesToLinks();
+  });
+});
+</script>

--- a/src/components/Screen.vue
+++ b/src/components/Screen.vue
@@ -7,6 +7,7 @@
 
       <div>
         <Library ref="library" @play="handlePlay" />
+        <NotesPanel class="mt-6" @play="handlePlay" />
       </div>
     </div>
 
@@ -32,6 +33,7 @@
   import { defineComponent, ref, watch } from 'vue';
   import Library from './Library.vue';
   import TracksPlayer from './TracksPlayer.vue';
+  import NotesPanel from './NotesPanel.vue';
   import FileTrack from '../models/FileTrack'
   import { Cookies } from '../models/Cookies';
 
@@ -40,6 +42,7 @@
     components: {
       Library,
       TracksPlayer,
+      NotesPanel,
     },
     setup() {
       const library = ref<InstanceType<typeof Library> | null>(null);
@@ -54,7 +57,7 @@
         isPlayerCollapsed.value = !isPlayerCollapsed.value;
       }
 
-      const handlePlay = (track: FileTrack, volume: number) => {
+      const handlePlay = (track: FileTrack) => {
         if (tracksPlayer.value) {
           tracksPlayer.value.addTrack(track.file, track.name, track.initialVolume);
         }


### PR DESCRIPTION
## Summary
- add quill and quill-mention for rich text editing
- create `NotesPanel` component for note taking and integrate with the library
- support `#` autocompletion of library music and link conversion

## Testing
- `npm run lint` *(fails: 24 errors)*
- `npm run build-no-icons` *(fails to resolve icon-sprite.svg)*

------
https://chatgpt.com/codex/tasks/task_b_685078ae6e008333b651ddb4d6fdd3ae