### PR TITLE
Fix drag and hidden player behaviours

### DIFF
--- a/src/components/IconSelector.vue
+++ b/src/components/IconSelector.vue
@@ -29,10 +29,11 @@
            :key="icon.path"
            class="flex flex-col items-center cursor-pointer text-gray-400 hover:text-purple-300"
            @click="chooseIcon(icon.name)">
-        <svg class="w-8 h-8 text-purple-400">
+        <svg class="w-8 h-8 text-purple-400"
+             :style="{ color: selectedColor }">
           <use :href="`#${icon.name}`" />
         </svg>
-        <span class="text-xs mt-1 text-gray-300">{{ icon.name }}</span>
+        <span class="text-xs text-gray-300">{{ icon.name }}</span>
       </div>
     </div>
   </div>

--- a/src/components/Library.vue
+++ b/src/components/Library.vue
@@ -86,6 +86,7 @@
                 <div v-if="trackMatchesSearch(element)">
                   <LibraryTrack :trackFile="element"
                                 :isListView="isListView"
+                                :dragDisabled="searchTerm !== ''"
                                 @remove-file="() => removeTrack(playlist, element)"
                                 @play="playTrack" />
                 </div>

--- a/src/components/LibraryTrack.vue
+++ b/src/components/LibraryTrack.vue
@@ -6,7 +6,7 @@
          draggable="true"
          @dragstart="onDragStart">
       <GripVertical class="w-4 h-4"
-                    :class="dragDisabled ? 'text-gray-700' : 'text-gray-400'" />
+                    :class="dragDisabled ? 'text-gray-600' : 'text-gray-400'" />
     </div>
     <div class="mr-3 cursor-pointer hover:bg-purple-400/20 rounded-full p-1" @click="isSelectingIcon = true">
       <svg v-if="trackFile.iconName" class="w-5 h-5" :style="{ color: trackFile.iconColor }">
@@ -49,9 +49,10 @@
   </li>
 
   <div v-else
-       class="track-drag-handle bg-gray-700 text-white rounded float-left w-12 ml-[2px] mb-[1px] h-12
+       class="track-drag-handle text-white rounded float-left w-12 ml-[2px] mb-[1px] h-12
        flex flex-col items-center justify-center cursor-pointer hover:bg-gray-600
        transition-colors relative"
+        :class="dragDisabled ? 'bg-gray-700' : ' bg-gray-600'" 
        draggable="true"
        @dragstart="onDragStart"
        @click="onPlay"

--- a/src/components/LibraryTrack.vue
+++ b/src/components/LibraryTrack.vue
@@ -1,10 +1,12 @@
 <template>
   <li v-if="isListView"
       class="flex items-center ml-5 rounded-lg bg-gray-700 hover:bg-gray-600 mb-1 shrink-0">
-    <div class="track-drag-handle cursor-move p-1 mr-2 rounded hover:bg-gray-600/25"
+    <div class="track-drag-handle p-1 mr-2 rounded hover:bg-gray-600/25"
+         :class="dragDisabled ? 'cursor-default' : 'cursor-move'"
          draggable="true"
          @dragstart="onDragStart">
-      <GripVertical class="w-4 h-4 text-gray-400" />
+      <GripVertical class="w-4 h-4"
+                    :class="dragDisabled ? 'text-gray-700' : 'text-gray-400'" />
     </div>
     <div class="mr-3 cursor-pointer hover:bg-purple-400/20 rounded-full p-1" @click="isSelectingIcon = true">
       <svg v-if="trackFile.iconName" class="w-5 h-5" :style="{ color: trackFile.iconColor }">
@@ -47,9 +49,11 @@
   </li>
 
   <div v-else
-       class="bg-gray-700 text-white rounded float-left w-12 ml-[2px] mb-[1px] h-12
+       class="track-drag-handle bg-gray-700 text-white rounded float-left w-12 ml-[2px] mb-[1px] h-12
        flex flex-col items-center justify-center cursor-pointer hover:bg-gray-600
        transition-colors relative"
+       draggable="true"
+       @dragstart="onDragStart"
        @click="onPlay"
        v-tooltip="trackFile.name">
     <svg v-if="trackFile.iconName" class="w-10 h-10 mb-1" :style="{ color: trackFile.iconColor }">
@@ -91,6 +95,10 @@
       isListView: {
         type: Boolean,
         required: true
+      },
+      dragDisabled: {
+        type: Boolean,
+        default: false,
       }
     },
     emits: ['remove-file', 'play'],

--- a/src/components/Screen.vue
+++ b/src/components/Screen.vue
@@ -10,7 +10,7 @@
       </div>
     </div>
 
-    <div v-if="!isPlayerCollapsed" class="w-96 bg-gray-800 p-6 flex flex-col justify-start border-l border-gray-700 relative">
+    <div v-show="!isPlayerCollapsed" class="w-96 bg-gray-800 p-6 flex flex-col justify-start border-l border-gray-700 relative">
       <button @click="togglePlayer"
               class="absolute -left-3 top-2 rounded-full p-1 text-purple-300 hover:text-purple-400 hover:bg-gray-700 transition-colors bg-gray-800 border border-gray-600 shadow-md">
         <ChevronRight class="w-4 h-4" />
@@ -19,7 +19,7 @@
       <TracksPlayer ref="tracksPlayer" />
     </div>
 
-    <div v-else class="relative w-6 flex items-center justify-center border-l border-gray-700">
+    <div v-show="isPlayerCollapsed" class="relative w-6 flex items-center justify-center border-l border-gray-700">
       <button @click="togglePlayer"
               class="absolute -left-3 top-2 rounded-full p-1 text-purple-300 hover:text-purple-400 hover:bg-gray-700 transition-colors bg-gray-800 border border-gray-600 shadow-md">
         <ChevronLeft class="w-4 h-4" />


### PR DESCRIPTION
## Summary
- allow passing search state to `LibraryTrack` and darken drag handle
- re-enable drag of board tracks
- keep `TracksPlayer` alive when collapsed so tracks stay

## Testing
- `npm run lint` *(fails: cannot find module 'eslint-plugin-vue')*
- `npm run type-check` *(fails: cannot find module '@/assets/icon-list.json')*

------
https://chatgpt.com/codex/tasks/task_b_6856c948601883339d4acd01a7bcc1ab