### PR TITLE
Fix drag and hidden player behaviours

### DIFF
--- a/src/components/IconSelector.vue
+++ b/src/components/IconSelector.vue
@@ -31,10 +31,11 @@
            :key="icon.path"
            class="flex flex-col items-center cursor-pointer text-gray-400 hover:text-purple-300"
            @click="chooseIcon(icon.name)">
-        <svg class="w-8 h-8 text-purple-400">
+        <svg class="w-8 h-8 text-purple-400"
+             :style="{ color: selectedColor }">
           <use :href="`#${icon.name}`" />
         </svg>
-        <span class="text-xs mt-1 text-gray-300">{{ icon.name }}</span>
+        <span class="text-xs text-gray-300">{{ icon.name }}</span>
       </div>
     </div>
   </div>

--- a/src/components/IconSelector.vue
+++ b/src/components/IconSelector.vue
@@ -44,7 +44,6 @@
 <script setup lang="ts">
   import { ref, computed, onMounted, watch, nextTick } from 'vue';
   import iconList from '@/assets/icon-list.json';
-  import { Cookies } from '@/models/Cookies';
   const props = defineProps<{ initialSearch?: string, initialColor?: string }>();
   const emit = defineEmits<{
     (e: 'icon-chosen', payload: { iconName: string; color: string }): void;
@@ -159,7 +158,7 @@
 
   /** Émission vers le parent quand on choisit une icône */
   function chooseIcon(iconName: string) {
-    emit('icon-chosen', { iconName, color: selectedColor.value });
+    emit('icon-chosen', { iconName, color: selectedColor.value ?? '#c084fc' });
   }
 </script>
 

--- a/src/components/IconSelector.vue
+++ b/src/components/IconSelector.vue
@@ -7,7 +7,9 @@
       <!-- Groupement de la barre de recherche et du bouton à droite -->
       <div class="flex items-center gap-2">
         <input type="text"
+               ref="searchInput"
                v-model="searchTerm"
+               @focus="selectAllSearch"
                class="p-2 rounded bg-gray-700 text-white mr-4"
                placeholder="Rechercher une icône..." />
         <input type="color"
@@ -39,9 +41,10 @@
 </template>
 
 <script setup lang="ts">
-  import { ref, computed, onMounted, watch  } from 'vue';
+  import { ref, computed, onMounted, watch, nextTick } from 'vue';
   import iconList from '@/assets/icon-list.json';
   import { Cookies } from '@/models/Cookies';
+  const props = defineProps<{ initialSearch?: string }>();
   const emit = defineEmits<{
     (e: 'icon-chosen', payload: { iconName: string; color: string }): void;
     (e: 'close'): void;
@@ -69,6 +72,7 @@
 
   /** Barre de recherche */
   const searchTerm = ref('');
+  const searchInput = ref<HTMLInputElement | null>(null);
   /** Nombre d’icônes qu’on affiche par “page” */
   const iconsPerPage = 20;
   const currentPage = ref(1);
@@ -125,6 +129,7 @@
 
   /** Gérer l'événement "scroll" manuellement */
   onMounted(() => {
+    searchTerm.value = props.initialSearch ?? '';
     // Initialiser la pagination
     resetPagination();
 
@@ -132,6 +137,11 @@
     if (scrollContainer.value) {
       scrollContainer.value.addEventListener('scroll', handleScroll);
     }
+
+    nextTick(() => {
+      searchInput.value?.focus();
+      searchInput.value?.select();
+    });
   });
 
   /** A chaque changement du champ de recherche, on reset la pagination */
@@ -142,6 +152,12 @@
   watch(selectedColor, (val) => {
     Cookies.set('lastColor', val)
   })
+
+  function selectAllSearch() {
+    nextTick(() => {
+      searchInput.value?.select();
+    });
+  }
 
   /** Émission vers le parent quand on choisit une icône */
   function chooseIcon(iconName: string) {

--- a/src/components/IconSelector.vue
+++ b/src/components/IconSelector.vue
@@ -45,7 +45,7 @@
   import { ref, computed, onMounted, watch, nextTick } from 'vue';
   import iconList from '@/assets/icon-list.json';
   import { Cookies } from '@/models/Cookies';
-  const props = defineProps<{ initialSearch?: string }>();
+  const props = defineProps<{ initialSearch?: string, initialColor?: string }>();
   const emit = defineEmits<{
     (e: 'icon-chosen', payload: { iconName: string; color: string }): void;
     (e: 'close'): void;
@@ -60,7 +60,7 @@
     name: string;
   }
 
-  const selectedColor = ref<string>(Cookies.get('lastColor') ?? '#c084fc');
+  const selectedColor = ref<string>();
 
   // 1) On scanne tous les fichiers .svg en lazy (sans eager:true)
   //const iconsModules = import.meta.glob('@/assets/game-icons/**/*.svg');
@@ -131,6 +131,7 @@
   /** Gérer l'événement "scroll" manuellement */
   onMounted(() => {
     searchTerm.value = props.initialSearch ?? '';
+    selectedColor.value = props.initialColor ?? '#c084fc';
     // Initialiser la pagination
     resetPagination();
 
@@ -149,10 +150,6 @@
   watch(filteredIcons, () => {
     resetPagination();
   });
-
-  watch(selectedColor, (val) => {
-    Cookies.set('lastColor', val)
-  })
 
   function selectAllSearch() {
     nextTick(() => {

--- a/src/components/Library.vue
+++ b/src/components/Library.vue
@@ -86,6 +86,7 @@
                 <div v-if="trackMatchesSearch(element)">
                   <LibraryTrack :trackFile="element"
                                 :isListView="isListView"
+                                :dragDisabled="searchTerm !== ''"
                                 @remove-file="() => removeTrack(playlist, element)"
                                 @play="playTrack" />
                 </div>

--- a/src/components/LibraryTrack.vue
+++ b/src/components/LibraryTrack.vue
@@ -69,7 +69,8 @@
     <div class="bg-gray-800 p-4 rounded shadow-lg w-3/4 max-w-2xl">
       <IconSelector @icon-chosen="onIconChosen"
                     @close="isSelectingIcon = false"
-                    :initial-search="trackFile.iconName" />
+                    :initial-search="trackFile.iconName" 
+                    :initial-color="trackFile.iconColor" />
     </div>
   </div>
 </template>

--- a/src/components/LibraryTrack.vue
+++ b/src/components/LibraryTrack.vue
@@ -1,10 +1,12 @@
 <template>
   <li v-if="isListView"
       class="flex items-center ml-5 rounded-lg bg-gray-700 hover:bg-gray-600 mb-1 shrink-0">
-    <div class="track-drag-handle cursor-move p-1 mr-2 rounded hover:bg-gray-600/25"
+    <div class="track-drag-handle p-1 mr-2 rounded hover:bg-gray-600/25"
+         :class="dragDisabled ? 'cursor-default' : 'cursor-move'"
          draggable="true"
          @dragstart="onDragStart">
-      <GripVertical class="w-4 h-4 text-gray-400" />
+      <GripVertical class="w-4 h-4"
+                    :class="dragDisabled ? 'text-gray-700' : 'text-gray-400'" />
     </div>
     <div class="mr-3 cursor-pointer hover:bg-purple-400/20 rounded-full p-1" @click="isSelectingIcon = true">
       <svg v-if="trackFile.iconName" class="w-5 h-5" :style="{ color: trackFile.iconColor }">
@@ -47,9 +49,11 @@
   </li>
 
   <div v-else
-       class="bg-gray-700 text-white rounded float-left w-12 ml-[2px] mb-[1px] h-12
+       class="track-drag-handle bg-gray-700 text-white rounded float-left w-12 ml-[2px] mb-[1px] h-12
        flex flex-col items-center justify-center cursor-pointer hover:bg-gray-600
        transition-colors relative"
+       draggable="true"
+       @dragstart="onDragStart"
        @click="onPlay"
        v-tooltip="trackFile.name">
     <svg v-if="trackFile.iconName" class="w-10 h-10 mb-1" :style="{ color: trackFile.iconColor }">
@@ -63,7 +67,8 @@
        class="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
     <div class="bg-gray-800 p-4 rounded shadow-lg w-3/4 max-w-2xl">
       <IconSelector @icon-chosen="onIconChosen"
-                    @close="isSelectingIcon = false" />
+                    @close="isSelectingIcon = false"
+                    :initial-search="trackFile.iconName" />
     </div>
   </div>
 </template>
@@ -91,6 +96,10 @@
       isListView: {
         type: Boolean,
         required: true
+      },
+      dragDisabled: {
+        type: Boolean,
+        default: false,
       }
     },
     emits: ['remove-file', 'play'],

--- a/src/components/LibraryTrack.vue
+++ b/src/components/LibraryTrack.vue
@@ -6,7 +6,7 @@
          draggable="true"
          @dragstart="onDragStart">
       <GripVertical class="w-4 h-4"
-                    :class="dragDisabled ? 'text-gray-700' : 'text-gray-400'" />
+                    :class="dragDisabled ? 'text-gray-600' : 'text-gray-400'" />
     </div>
     <div class="mr-3 cursor-pointer hover:bg-purple-400/20 rounded-full p-1" @click="isSelectingIcon = true">
       <svg v-if="trackFile.iconName" class="w-5 h-5" :style="{ color: trackFile.iconColor }">
@@ -49,9 +49,10 @@
   </li>
 
   <div v-else
-       class="track-drag-handle bg-gray-700 text-white rounded float-left w-12 ml-[2px] mb-[1px] h-12
+       class="track-drag-handle text-white rounded float-left w-12 ml-[2px] mb-[1px] h-12
        flex flex-col items-center justify-center cursor-pointer hover:bg-gray-600
        transition-colors relative"
+        :class="dragDisabled ? 'bg-gray-700' : ' bg-gray-600'" 
        draggable="true"
        @dragstart="onDragStart"
        @click="onPlay"

--- a/src/components/Screen.vue
+++ b/src/components/Screen.vue
@@ -10,7 +10,7 @@
       </div>
     </div>
 
-    <div v-if="!isPlayerCollapsed" class="w-96 bg-gray-800 p-6 flex flex-col justify-start border-l border-gray-700 relative">
+    <div v-show="!isPlayerCollapsed" class="w-96 bg-gray-800 p-6 flex flex-col justify-start border-l border-gray-700 relative">
       <button @click="togglePlayer"
               class="absolute -left-3 top-2 rounded-full p-1 text-purple-300 hover:text-purple-400 hover:bg-gray-700 transition-colors bg-gray-800 border border-gray-600 shadow-md">
         <ChevronRight class="w-4 h-4" />
@@ -19,7 +19,7 @@
       <TracksPlayer ref="tracksPlayer" />
     </div>
 
-    <div v-else class="relative w-6 flex items-center justify-center border-l border-gray-700">
+    <div v-show="isPlayerCollapsed" class="relative w-6 flex items-center justify-center border-l border-gray-700">
       <button @click="togglePlayer"
               class="absolute -left-3 top-2 rounded-full p-1 text-purple-300 hover:text-purple-400 hover:bg-gray-700 transition-colors bg-gray-800 border border-gray-600 shadow-md">
         <ChevronLeft class="w-4 h-4" />


### PR DESCRIPTION
## Summary
- allow passing search state to `LibraryTrack` and darken drag handle
- re-enable drag of board tracks
- keep `TracksPlayer` alive when collapsed so tracks stay
- prefill icon selector search with track icon and auto-select text

## Testing
- `npm run lint` *(fails: cannot find module 'eslint-plugin-vue')*
- `npm run type-check` *(fails: cannot find module '@/assets/icon-list.json')*

------
https://chatgpt.com/codex/tasks/task_b_6856c948601883339d4acd01a7bcc1ab