### PR TITLE
Implement playlist prefix import

### DIFF
--- a/src/components/Library.vue
+++ b/src/components/Library.vue
@@ -7,7 +7,7 @@
           <h2 class="text-xl font-bold text-purple-300 mr-2">Bibliothèque</h2>
           <Uploader @file-selected="handleFileSelected" />
           <HelpCircle
-            class="w-4 h-4 text-purple-300 ml-1 cursor-help"
+            class="w-5 text-gray-400 ml-1 cursor-help"
             v-tooltip="helpText"
           />
         </div>
@@ -97,17 +97,13 @@
               </template>
               <template #footer>
                 <div v-if="visibleTracks(playlist).length === 0">
-                  <p class="text-gray-400 italic">
-                    C'est vide ! 👀🕸️
+                  <p class="text-gray-400 text-xl">
+                    🕸️🕸️🕸
                   </p>
                 </div>
               </template>
             </draggable>
-
-
-
           </div>
-
         </template>
       </draggable>
       <div class="clear-both"></div>

--- a/src/components/Library.vue
+++ b/src/components/Library.vue
@@ -6,6 +6,10 @@
         <div class="flex items-center">
           <h2 class="text-xl font-bold text-purple-300 mr-2">Bibliothèque</h2>
           <Uploader @file-selected="handleFileSelected" />
+          <HelpCircle
+            class="w-4 h-4 text-purple-300 ml-1 cursor-help"
+            v-tooltip="helpText"
+          />
         </div>
         <div class="flex items-center gap-2">
           <input
@@ -142,7 +146,8 @@
   import Uploader from './Uploader.vue';
   import ImportFileDragOverlay from './ImportFileDragOverlay.vue';
   import ViewModePlayerToggle from './ViewModePlayerToggle.vue';
-  import { GripVertical } from 'lucide-vue-next'
+  import { GripVertical, HelpCircle } from 'lucide-vue-next'
+  import tooltip from '@/directives/tooltip';
   import { Cookies } from '@/models/Cookies';
 
   // Directive autofocus
@@ -156,14 +161,17 @@
     name: 'Library',
     components: {
       LibraryTrack, Uploader, ImportFileDragOverlay,
-      ViewModePlayerToggle, draggable, GripVertical
+      ViewModePlayerToggle, draggable, GripVertical, HelpCircle
     },
-    directives: { focus },
+    directives: { focus, tooltip },
     setup(_, { emit }) {
       const playlists = ref<Playlist[]>([]);
       const isListView = ref(Cookies.get('viewMode') !== 'soundboard');
       const searchTerm = ref('');
       const playlistNameInput = ref<HTMLInputElement | null>(null);
+      const helpText =
+        'Pour ranger directement votre fichier de musique dans une playlist en particulier, ' +
+        'préfixez son nom par "Nom_Playlist --". Exemple : "MaPlaylist -- MonSon.mp3"';
       const resizing = ref<Playlist | null>(null);
       let startX = 0;
       let startWidth = 0;
@@ -196,12 +204,39 @@
 
       async function addFile(file: File) {
         if (!playlists.value.length) await ensureLibrary();
-        const lib = playlists.value[0];
-        const ft = new FileTrack(file, file.name);
-        ft.playlistId = lib.id;
-        ft.order = lib.tracks.length;
+        const { playlistName, trackName } = parseName(file.name);
+
+        let target: Playlist | undefined;
+        if (playlistName) {
+          target = playlists.value.find(
+            p => p.name.toLowerCase() === playlistName.toLowerCase()
+          );
+          if (!target) {
+            target = new Playlist(playlistName);
+            target.id = await DB_AddPlaylist(target);
+            playlists.value.push(target);
+          }
+        } else {
+          target = playlists.value[0];
+        }
+
+        const ft = new FileTrack(file, trackName);
+        ft.playlistId = target.id;
+        ft.order = target.tracks.length;
         ft.id = await DB_AddTrack(ft);
-        lib.tracks.push(ft);
+        target.tracks.push(ft);
+      }
+
+      function parseName(name: string) {
+        const parts = name.split('--');
+        let playlistName: string | undefined;
+        let trackName = name;
+        if (parts.length > 1) {
+          playlistName = parts[0].trim();
+          trackName = parts.slice(1).join('--').trim();
+        }
+        trackName = trackName.replace(/\.[^/.]+$/, '');
+        return { playlistName, trackName };
       }
 
       async function ensureLibrary() {
@@ -305,6 +340,7 @@
         startResize,
         trackMatchesSearch,
         visibleTracks,
+        helpText,
       };
     }
   });

--- a/src/components/Library.vue
+++ b/src/components/Library.vue
@@ -208,13 +208,16 @@
 
         let target: Playlist | undefined;
         if (playlistName) {
-          target = playlists.value.find(
+          const idx = playlists.value.findIndex(
             p => p.name.toLowerCase() === playlistName.toLowerCase()
           );
-          if (!target) {
-            target = new Playlist(playlistName);
-            target.id = await DB_AddPlaylist(target);
-            playlists.value.push(target);
+          if (idx !== -1) {
+            target = playlists.value[idx];
+          } else {
+            const newPl = new Playlist(playlistName);
+            newPl.id = await DB_AddPlaylist(newPl);
+            playlists.value.push(newPl);
+            target = playlists.value[playlists.value.length - 1];
           }
         } else {
           target = playlists.value[0];

--- a/src/persistance/TrackService.ts
+++ b/src/persistance/TrackService.ts
@@ -8,7 +8,7 @@ import type { TrackDB } from './TrackDB';
 export async function DB_AddTrack(track: FileTrack): Promise<number> {
   // On construit l'objet qu'on veut stocker
     const stored: TrackDB = {
-      name: track.file.name,
+      name: track.name,
       initialVolume: track.initialVolume,
       blob: track.file,
       iconName: track.iconName,


### PR DESCRIPTION
## Summary
- parse playlist name from uploaded file name and create playlist if needed
- show help icon next to uploader with instructions
- store sanitized track name in DB

## Testing
- `npm run lint` *(fails: vue and ts lint errors)*
- `npm run type-check` *(fails: cannot find module '@/assets/icon-list.json')*

------
https://chatgpt.com/codex/tasks/task_b_6856d34d23e08333a3f1951a4ceed448