### PR TITLE
Add import/export feature with settings modal

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "dexie": "^4.0.10",
+        "jszip": "^3.10.1",
         "lucide-vue-next": "^0.471.0",
         "svgstore": "^3.0.1",
         "tippy.js": "^6.3.7",
@@ -2883,6 +2884,12 @@
         "url": "https://github.com/sponsors/mesqueeb"
       }
     },
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+      "license": "MIT"
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -3939,6 +3946,12 @@
         "node": ">= 4"
       }
     },
+    "node_modules/immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
+      "license": "MIT"
+    },
     "node_modules/import-fresh": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
@@ -3965,6 +3978,12 @@
       "engines": {
         "node": ">=0.8.19"
       }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
     },
     "node_modules/is-binary-path": {
       "version": "2.1.0",
@@ -4141,6 +4160,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "license": "MIT"
+    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -4264,6 +4289,18 @@
         "graceful-fs": "^4.1.6"
       }
     },
+    "node_modules/jszip": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
+      "integrity": "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==",
+      "license": "(MIT OR GPL-3.0-or-later)",
+      "dependencies": {
+        "lie": "~3.3.0",
+        "pako": "~1.0.2",
+        "readable-stream": "~2.3.6",
+        "setimmediate": "^1.0.5"
+      }
+    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -4293,6 +4330,15 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/lie": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+      "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "immediate": "~3.0.5"
       }
     },
     "node_modules/lilconfig": {
@@ -4770,6 +4816,12 @@
       "dev": true,
       "license": "BlueOak-1.0.0"
     },
+    "node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "license": "(MIT AND Zlib)"
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -5108,6 +5160,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "license": "MIT"
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -5161,6 +5219,21 @@
       },
       "engines": {
         "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
       }
     },
     "node_modules/readdirp": {
@@ -5301,6 +5374,12 @@
         "queue-microtask": "^1.2.2"
       }
     },
+    "node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
+    },
     "node_modules/semver": {
       "version": "7.6.3",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
@@ -5313,6 +5392,12 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/setimmediate": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
+      "license": "MIT"
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
@@ -5401,6 +5486,15 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
       }
     },
     "node_modules/string-width": {
@@ -5902,7 +5996,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/vite": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   },
   "dependencies": {
     "dexie": "^4.0.10",
+    "jszip": "^3.10.1",
     "lucide-vue-next": "^0.471.0",
     "svgstore": "^3.0.1",
     "tippy.js": "^6.3.7",

--- a/src/components/CollapsibleSidebar.vue
+++ b/src/components/CollapsibleSidebar.vue
@@ -1,19 +1,20 @@
 <template>
-  <div
-    :class="[
+  <div :class="[
       'relative border-l border-gray-700',
       collapsed ? 'w-6 flex items-center justify-center' : 'w-96 bg-gray-800 p-6 flex flex-col justify-start'
-    ]"
-  >
-    <button
-      @click="toggle"
-      class="absolute -left-3 top-2 rounded-full p-1 text-purple-300 hover:text-purple-400 hover:bg-gray-700 transition-colors bg-gray-800 border border-gray-600 shadow-md"
-    >
+    ]">
+    <button @click="toggle"
+            class="absolute -left-3 top-2 rounded-full p-1 text-purple-300 hover:text-purple-400 hover:bg-gray-700 transition-colors bg-gray-800 border border-gray-600 shadow-md">
       <ChevronLeft v-if="collapsed" class="w-4 h-4" />
       <ChevronRight v-else class="w-4 h-4" />
     </button>
+
+    <!-- Bouton en forme de roue crantée -->
+    <button @click="openSettings" class="absolute -left-3 top-12 rounded-full p-1 text-purple-300 hover:text-purple-400 hover:bg-gray-700 transition-colors bg-gray-800 border border-gray-600 shadow-md">
+      <Settings class="w-4 h-4" />
+    </button>
+
     <slot v-if="!collapsed" />
-    <slot name="footer" />
   </div>
 </template>
 
@@ -26,14 +27,18 @@ export default defineComponent({
   props: {
     collapsed: { type: Boolean, required: true }
   },
-  emits: ['update:collapsed'],
+  emits: ['update:collapsed', 'open-settings'],
   components: { ChevronRight, ChevronLeft },
   setup(props, { emit }) {
     function toggle() {
       emit('update:collapsed', !props.collapsed);
     }
 
-    return { toggle };
+    function openSettings() {
+      emit('open-settings')
+    }
+
+    return { toggle, openSettings };
   }
 });
 </script>

--- a/src/components/CollapsibleSidebar.vue
+++ b/src/components/CollapsibleSidebar.vue
@@ -1,0 +1,35 @@
+<template>
+  <div v-if="!collapsed" class="w-96 bg-gray-800 p-6 flex flex-col justify-start border-l border-gray-700 relative">
+    <button @click="toggle" class="absolute -left-3 top-2 rounded-full p-1 text-purple-300 hover:text-purple-400 hover:bg-gray-700 transition-colors bg-gray-800 border border-gray-600 shadow-md">
+      <ChevronRight class="w-4 h-4" />
+    </button>
+    <slot />
+    <slot name="footer" />
+  </div>
+  <div v-else class="relative w-6 flex items-center justify-center border-l border-gray-700">
+    <button @click="toggle" class="absolute -left-3 top-2 rounded-full p-1 text-purple-300 hover:text-purple-400 hover:bg-gray-700 transition-colors bg-gray-800 border border-gray-600 shadow-md">
+      <ChevronLeft class="w-4 h-4" />
+    </button>
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue';
+import { ChevronRight, ChevronLeft } from 'lucide-vue-next';
+
+export default defineComponent({
+  name: 'CollapsibleSidebar',
+  props: {
+    collapsed: { type: Boolean, required: true }
+  },
+  emits: ['update:collapsed'],
+  components: { ChevronRight, ChevronLeft },
+  setup(props, { emit }) {
+    function toggle() {
+      emit('update:collapsed', !props.collapsed);
+    }
+
+    return { toggle };
+  }
+});
+</script>

--- a/src/components/CollapsibleSidebar.vue
+++ b/src/components/CollapsibleSidebar.vue
@@ -1,15 +1,19 @@
 <template>
-  <div v-if="!collapsed" class="w-96 bg-gray-800 p-6 flex flex-col justify-start border-l border-gray-700 relative">
-    <button @click="toggle" class="absolute -left-3 top-2 rounded-full p-1 text-purple-300 hover:text-purple-400 hover:bg-gray-700 transition-colors bg-gray-800 border border-gray-600 shadow-md">
-      <ChevronRight class="w-4 h-4" />
+  <div
+    :class="[
+      'relative border-l border-gray-700',
+      collapsed ? 'w-6 flex items-center justify-center' : 'w-96 bg-gray-800 p-6 flex flex-col justify-start'
+    ]"
+  >
+    <button
+      @click="toggle"
+      class="absolute -left-3 top-2 rounded-full p-1 text-purple-300 hover:text-purple-400 hover:bg-gray-700 transition-colors bg-gray-800 border border-gray-600 shadow-md"
+    >
+      <ChevronLeft v-if="collapsed" class="w-4 h-4" />
+      <ChevronRight v-else class="w-4 h-4" />
     </button>
-    <slot />
+    <slot v-if="!collapsed" />
     <slot name="footer" />
-  </div>
-  <div v-else class="relative w-6 flex items-center justify-center border-l border-gray-700">
-    <button @click="toggle" class="absolute -left-3 top-2 rounded-full p-1 text-purple-300 hover:text-purple-400 hover:bg-gray-700 transition-colors bg-gray-800 border border-gray-600 shadow-md">
-      <ChevronLeft class="w-4 h-4" />
-    </button>
   </div>
 </template>
 

--- a/src/components/ConfirmationModal.vue
+++ b/src/components/ConfirmationModal.vue
@@ -1,4 +1,5 @@
 <template>
+  <!-- Arrière-plan semi-transparent bloquant -->
   <div class="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
     <div class="bg-gray-800 p-6 rounded-lg w-80 text-center">
       <p class="text-white mb-4">{{ message }}</p>
@@ -12,6 +13,8 @@
 
 <script lang="ts">
 import { defineComponent } from 'vue';
+
+// Composant affichant une boîte de dialogue de confirmation générique
 export default defineComponent({
   name: 'ConfirmationModal',
   props: {

--- a/src/components/ConfirmationModal.vue
+++ b/src/components/ConfirmationModal.vue
@@ -1,0 +1,22 @@
+<template>
+  <div class="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
+    <div class="bg-gray-800 p-6 rounded-lg w-80 text-center">
+      <p class="text-white mb-4">{{ message }}</p>
+      <div class="flex justify-end gap-2">
+        <button @click="$emit('cancel')" class="px-3 py-1 bg-gray-600 rounded text-white">Annuler</button>
+        <button @click="$emit('confirm')" class="px-3 py-1 bg-purple-600 rounded text-white">Confirmer</button>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue';
+export default defineComponent({
+  name: 'ConfirmationModal',
+  props: {
+    message: { type: String, required: true }
+  },
+  emits: ['confirm', 'cancel']
+});
+</script>

--- a/src/components/Screen.vue
+++ b/src/components/Screen.vue
@@ -10,12 +10,14 @@
       </div>
     </div>
 
-    <CollapsibleSidebar v-model:collapsed="isPlayerCollapsed">
+    <CollapsibleSidebar v-model:collapsed="isPlayerCollapsed" @open-settings="handleOpenSettings">
       <TracksPlayer ref="tracksPlayer" />
-      <template #footer>
-        <SettingsModal class="absolute -left-3 bottom-10 rounded-full p-1 text-purple-300 hover:text-purple-400 hover:bg-gray-700 transition-colors bg-gray-800 border border-gray-600 shadow-md" />
-      </template>
     </CollapsibleSidebar>
+
+    <SettingsModal
+      :isOpen="showSettings"
+      @close="showSettings = false" />
+
   </div>
 </template>
 
@@ -41,6 +43,7 @@
     setup() {
       const library = ref<InstanceType<typeof Library> | null>(null);
       const tracksPlayer = ref<InstanceType<typeof TracksPlayer> | null>(null);
+      const showSettings = ref(false)
 
       const isPlayerCollapsed = ref(Cookies.get('playerCollapsed') === 'true');
       watch(isPlayerCollapsed, val => {
@@ -53,11 +56,17 @@
         }
       };
 
+      const handleOpenSettings = () => {
+        showSettings.value = true
+      }
+
       return {
         library,
         tracksPlayer,
         handlePlay,
         isPlayerCollapsed,
+        handleOpenSettings,
+        showSettings,
       };
     },
   });

--- a/src/components/Screen.vue
+++ b/src/components/Screen.vue
@@ -3,8 +3,6 @@
     <div class="p-8 overflow-auto min-w-[522px]">
       <div class="flex items-center justify-between">
         <h1 class="text-3xl font-bold text-purple-400 mb-8">MJ Screen Jukebox</h1>
-        <!-- Accès aux actions d'import/export -->
-        <SettingsModal />
       </div>
 
       <div>
@@ -12,21 +10,12 @@
       </div>
     </div>
 
-    <div v-show="!isPlayerCollapsed" class="w-96 bg-gray-800 p-6 flex flex-col justify-start border-l border-gray-700 relative">
-      <button @click="togglePlayer"
-              class="absolute -left-3 top-2 rounded-full p-1 text-purple-300 hover:text-purple-400 hover:bg-gray-700 transition-colors bg-gray-800 border border-gray-600 shadow-md">
-        <ChevronRight class="w-4 h-4" />
-      </button>
-
+    <CollapsibleSidebar v-model:collapsed="isPlayerCollapsed">
       <TracksPlayer ref="tracksPlayer" />
-    </div>
-
-    <div v-show="isPlayerCollapsed" class="relative w-6 flex items-center justify-center border-l border-gray-700">
-      <button @click="togglePlayer"
-              class="absolute -left-3 top-2 rounded-full p-1 text-purple-300 hover:text-purple-400 hover:bg-gray-700 transition-colors bg-gray-800 border border-gray-600 shadow-md">
-        <ChevronLeft class="w-4 h-4" />
-      </button>
-    </div>
+      <template #footer>
+        <SettingsModal class="absolute -left-3 bottom-10 rounded-full p-1 text-purple-300 hover:text-purple-400 hover:bg-gray-700 transition-colors bg-gray-800 border border-gray-600 shadow-md" />
+      </template>
+    </CollapsibleSidebar>
   </div>
 </template>
 
@@ -36,6 +25,8 @@
   import TracksPlayer from './TracksPlayer.vue';
   // Bouton ouvrant la modale d'import/export
   import SettingsModal from './SettingsModal.vue';
+  // Barre latérale rétractable pour le lecteur
+  import CollapsibleSidebar from './CollapsibleSidebar.vue';
   import FileTrack from '../models/FileTrack'
   import { Cookies } from '../models/Cookies';
 
@@ -45,6 +36,7 @@
       Library,
       TracksPlayer,
       SettingsModal,
+      CollapsibleSidebar,
     },
     setup() {
       const library = ref<InstanceType<typeof Library> | null>(null);
@@ -54,10 +46,6 @@
       watch(isPlayerCollapsed, val => {
         Cookies.set('playerCollapsed', val ? 'true' : 'false');
       });
-
-      function togglePlayer() {
-        isPlayerCollapsed.value = !isPlayerCollapsed.value;
-      }
 
       const handlePlay = (track: FileTrack) => {
         if (tracksPlayer.value) {
@@ -70,7 +58,6 @@
         tracksPlayer,
         handlePlay,
         isPlayerCollapsed,
-        togglePlayer,
       };
     },
   });

--- a/src/components/Screen.vue
+++ b/src/components/Screen.vue
@@ -3,6 +3,7 @@
     <div class="p-8 overflow-auto min-w-[522px]">
       <div class="flex items-center justify-between">
         <h1 class="text-3xl font-bold text-purple-400 mb-8">MJ Screen Jukebox</h1>
+        <!-- Accès aux actions d'import/export -->
         <SettingsModal />
       </div>
 
@@ -33,6 +34,7 @@
   import { defineComponent, ref, watch } from 'vue';
   import Library from './Library.vue';
   import TracksPlayer from './TracksPlayer.vue';
+  // Bouton ouvrant la modale d'import/export
   import SettingsModal from './SettingsModal.vue';
   import FileTrack from '../models/FileTrack'
   import { Cookies } from '../models/Cookies';

--- a/src/components/Screen.vue
+++ b/src/components/Screen.vue
@@ -3,6 +3,7 @@
     <div class="p-8 overflow-auto min-w-[522px]">
       <div class="flex items-center justify-between">
         <h1 class="text-3xl font-bold text-purple-400 mb-8">MJ Screen Jukebox</h1>
+        <SettingsModal />
       </div>
 
       <div>
@@ -32,6 +33,7 @@
   import { defineComponent, ref, watch } from 'vue';
   import Library from './Library.vue';
   import TracksPlayer from './TracksPlayer.vue';
+  import SettingsModal from './SettingsModal.vue';
   import FileTrack from '../models/FileTrack'
   import { Cookies } from '../models/Cookies';
 
@@ -40,6 +42,7 @@
     components: {
       Library,
       TracksPlayer,
+      SettingsModal,
     },
     setup() {
       const library = ref<InstanceType<typeof Library> | null>(null);

--- a/src/components/SettingsModal.vue
+++ b/src/components/SettingsModal.vue
@@ -1,14 +1,18 @@
 <template>
   <div class="relative inline-block">
+    <!-- Bouton en forme de roue crantée -->
     <button @click="isOpen = true" class="p-2 rounded-full hover:bg-gray-700 transition-colors">
       <Settings class="w-6 h-6 text-purple-400" />
     </button>
 
+    <!-- Fenêtre modale contenant les options -->
     <div v-if="isOpen" class="fixed inset-0 bg-black/50 flex items-center justify-center z-40">
       <div class="bg-gray-800 p-6 rounded-lg w-80">
         <h3 class="text-purple-300 text-lg font-bold mb-4">Options</h3>
         <div class="flex flex-col gap-3">
+          <!-- Lance l'export de la bibliothèque -->
           <button @click="triggerExport" class="px-3 py-2 bg-purple-600 rounded text-white">Exporter</button>
+          <!-- Sélecteur de fichier pour l'import -->
           <label class="px-3 py-2 bg-purple-600 rounded text-white text-center cursor-pointer">
             Importer
             <input type="file" class="hidden" @change="onFileChange" />
@@ -18,6 +22,7 @@
       </div>
     </div>
 
+    <!-- Modale de confirmation avant l'import -->
     <ConfirmationModal
       v-if="toImport"
       :message="'Importer ce fichier écrasera tout le travail en cours. Continuer ?'"
@@ -36,9 +41,12 @@ export default defineComponent({
   name: 'SettingsModal',
   components: { ConfirmationModal },
   setup() {
+    // Etat de visibilité de la modale
     const isOpen = ref(false);
+    // Fichier sélectionné pour l'import
     const toImport = ref<File | null>(null);
 
+    // Génère l'archive et déclenche le téléchargement
     async function triggerExport() {
       const blob = await exportLibrary();
       const url = URL.createObjectURL(blob);
@@ -49,6 +57,7 @@ export default defineComponent({
       URL.revokeObjectURL(url);
     }
 
+    // Stocke le fichier choisi pour importation
     function onFileChange(e: Event) {
       const file = (e.target as HTMLInputElement).files?.[0];
       if (file) {
@@ -56,6 +65,7 @@ export default defineComponent({
       }
     }
 
+    // Applique l'import et recharge la page
     async function confirmImport() {
       if (toImport.value) {
         await importLibrary(toImport.value);
@@ -65,6 +75,7 @@ export default defineComponent({
       }
     }
 
+    // Données et méthodes exposées au template
     return { isOpen, toImport, triggerExport, onFileChange, confirmImport };
   }
 });

--- a/src/components/SettingsModal.vue
+++ b/src/components/SettingsModal.vue
@@ -1,0 +1,71 @@
+<template>
+  <div class="relative inline-block">
+    <button @click="isOpen = true" class="p-2 rounded-full hover:bg-gray-700 transition-colors">
+      <Settings class="w-6 h-6 text-purple-400" />
+    </button>
+
+    <div v-if="isOpen" class="fixed inset-0 bg-black/50 flex items-center justify-center z-40">
+      <div class="bg-gray-800 p-6 rounded-lg w-80">
+        <h3 class="text-purple-300 text-lg font-bold mb-4">Options</h3>
+        <div class="flex flex-col gap-3">
+          <button @click="triggerExport" class="px-3 py-2 bg-purple-600 rounded text-white">Exporter</button>
+          <label class="px-3 py-2 bg-purple-600 rounded text-white text-center cursor-pointer">
+            Importer
+            <input type="file" class="hidden" @change="onFileChange" />
+          </label>
+          <button @click="isOpen = false" class="px-3 py-2 bg-gray-600 rounded text-white">Fermer</button>
+        </div>
+      </div>
+    </div>
+
+    <ConfirmationModal
+      v-if="toImport"
+      :message="'Importer ce fichier écrasera tout le travail en cours. Continuer ?'"
+      @confirm="confirmImport"
+      @cancel="toImport = null"
+    />
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent, ref } from 'vue';
+import { exportLibrary, importLibrary } from '@/persistance/ImportExportService';
+import ConfirmationModal from './ConfirmationModal.vue';
+
+export default defineComponent({
+  name: 'SettingsModal',
+  components: { ConfirmationModal },
+  setup() {
+    const isOpen = ref(false);
+    const toImport = ref<File | null>(null);
+
+    async function triggerExport() {
+      const blob = await exportLibrary();
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = 'library.mjszip';
+      a.click();
+      URL.revokeObjectURL(url);
+    }
+
+    function onFileChange(e: Event) {
+      const file = (e.target as HTMLInputElement).files?.[0];
+      if (file) {
+        toImport.value = file;
+      }
+    }
+
+    async function confirmImport() {
+      if (toImport.value) {
+        await importLibrary(toImport.value);
+        toImport.value = null;
+        isOpen.value = false;
+        window.location.reload();
+      }
+    }
+
+    return { isOpen, toImport, triggerExport, onFileChange, confirmImport };
+  }
+});
+</script>

--- a/src/components/SettingsModal.vue
+++ b/src/components/SettingsModal.vue
@@ -32,10 +32,10 @@
 
     <!-- Modale de confirmation avant l'import -->
     <ConfirmationModal
-      v-if="toImport"
+      v-if="showConfirmation"
       :message="'Importer ce fichier écrasera tout le travail en cours. Continuer ?'"
       @confirm="confirmImport"
-      @cancel="toImport = null"
+      @cancel="showConfirmation = null"
     />
   </div>
 </template>
@@ -55,6 +55,7 @@ export default defineComponent({
   setup(props, { emit }) {
     // Fichier sélectionné pour l'import
     const toImport = ref<File | null>(null);
+    const showConfirmation = ref<boolean | null>(null);
     const errorMessage = ref<string | null>(null);
 
     // Génère l'archive et déclenche le téléchargement
@@ -80,6 +81,7 @@ export default defineComponent({
       const file = (e.target as HTMLInputElement).files?.[0];
       if (file) {
         toImport.value = file;
+        showConfirmation.value = true;
       }
     }
 
@@ -88,6 +90,7 @@ export default defineComponent({
       if (toImport.value) {
         errorMessage.value = null;
         try {
+          showConfirmation.value = false;
           await importLibrary(toImport.value);
           toImport.value = null;
           emit('close');
@@ -102,6 +105,7 @@ export default defineComponent({
     return {
       errorMessage,
       toImport,
+      showConfirmation,
       triggerExport,
       onFileChange,
       confirmImport

--- a/src/components/SettingsModal.vue
+++ b/src/components/SettingsModal.vue
@@ -4,17 +4,29 @@
     <!-- Fenêtre modale contenant les options -->
     <div v-if="isOpen" class="fixed inset-0 bg-black/50 flex items-center justify-center z-40">
       <div class="bg-gray-800 p-6 rounded-lg w-80">
-        <h3 class="text-purple-300 text-lg font-bold mb-4">Options</h3>
+        <div class="flex items-center justify-between">
+
+          <h3 class="text-purple-300 text-lg font-bold mb-4">Paramétrage</h3>
+          <button class="px-3 py-2 mb-4 rounded text-white hover:text-red-400 transition-colors"
+                  @click="$emit('close')">
+            <CircleX />
+          </button>
+        </div>
         <div class="flex flex-col gap-3">
           <!-- Lance l'export de la bibliothèque -->
-          <button @click="triggerExport" class="px-3 py-2 bg-purple-600 rounded text-white">Exporter</button>
+          <button @click="triggerExport" class="px-3 py-2 bg-purple-600 hover:bg-purple-500 rounded text-white">Exporter</button>
           <!-- Sélecteur de fichier pour l'import -->
-          <label class="px-3 py-2 bg-purple-600 rounded text-white text-center cursor-pointer">
+          <label class="px-3 py-2 bg-purple-600 hover:bg-purple-500 rounded text-white text-center cursor-pointer">
             Importer
             <input type="file" class="hidden" @change="onFileChange" />
           </label>
-          <button  @click="$emit('close')" class="px-3 py-2 bg-gray-600 rounded text-white">Fermer</button>
         </div>
+
+        <!-- Affichage d'une erreur -->
+        <p v-if="errorMessage"
+           class="mt-4 text-sm text-red-400 bg-red-900/30 px-3 py-2 rounded border border-red-500">
+          {{ errorMessage }}
+        </p>
       </div>
     </div>
 
@@ -43,20 +55,28 @@ export default defineComponent({
   setup(props, { emit }) {
     // Fichier sélectionné pour l'import
     const toImport = ref<File | null>(null);
+    const errorMessage = ref<string | null>(null);
 
     // Génère l'archive et déclenche le téléchargement
     async function triggerExport() {
-      const blob = await exportLibrary();
-      const url = URL.createObjectURL(blob);
-      const a = document.createElement('a');
-      a.href = url;
-      a.download = 'library.mjszip';
-      a.click();
-      URL.revokeObjectURL(url);
+      errorMessage.value = null;
+      try {
+        const blob = await exportLibrary();
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = 'library.mjszip';
+        a.click();
+        URL.revokeObjectURL(url);
+
+      } catch (e: any) {
+        errorMessage.value = "Erreur lors de l'export : " + (e?.message || 'inconnue');
+      }
     }
 
     // Stocke le fichier choisi pour importation
     function onFileChange(e: Event) {
+      errorMessage.value = null;
       const file = (e.target as HTMLInputElement).files?.[0];
       if (file) {
         toImport.value = file;
@@ -66,15 +86,26 @@ export default defineComponent({
     // Applique l'import et recharge la page
     async function confirmImport() {
       if (toImport.value) {
-        await importLibrary(toImport.value);
-        toImport.value = null;
-        emit('close');
-        window.location.reload();
+        errorMessage.value = null;
+        try {
+          await importLibrary(toImport.value);
+          toImport.value = null;
+          emit('close');
+          window.location.reload();
+        } catch (e: any) {
+          errorMessage.value = "Erreur lors de l'import : " + (e?.message || 'inconnue');
+        }
       }
     }
 
     // Données et méthodes exposées au template
-    return { toImport, triggerExport, onFileChange, confirmImport };
+    return {
+      errorMessage,
+      toImport,
+      triggerExport,
+      onFileChange,
+      confirmImport
+    };
   }
 });
 </script>

--- a/src/components/SettingsModal.vue
+++ b/src/components/SettingsModal.vue
@@ -1,8 +1,8 @@
 <template>
-  <div class="relative inline-block">
+  <div class="relative">
     <!-- Bouton en forme de roue crantée -->
-    <button @click="isOpen = true" class="p-2 rounded-full hover:bg-gray-700 transition-colors">
-      <Settings class="w-6 h-6 text-purple-400" />
+    <button @click="isOpen = true" class="absolute -left-3 bottom-10 rounded-full p-1 text-purple-300 hover:text-purple-400 hover:bg-gray-700 transition-colors bg-gray-800 border border-gray-600 shadow-md">
+      <Settings class="w-6 h-6" />
     </button>
 
     <!-- Fenêtre modale contenant les options -->

--- a/src/components/SettingsModal.vue
+++ b/src/components/SettingsModal.vue
@@ -1,9 +1,5 @@
 <template>
   <div class="relative">
-    <!-- Bouton en forme de roue crantée -->
-    <button @click="isOpen = true" class="absolute -left-3 bottom-10 rounded-full p-1 text-purple-300 hover:text-purple-400 hover:bg-gray-700 transition-colors bg-gray-800 border border-gray-600 shadow-md">
-      <Settings class="w-6 h-6" />
-    </button>
 
     <!-- Fenêtre modale contenant les options -->
     <div v-if="isOpen" class="fixed inset-0 bg-black/50 flex items-center justify-center z-40">
@@ -17,7 +13,7 @@
             Importer
             <input type="file" class="hidden" @change="onFileChange" />
           </label>
-          <button @click="isOpen = false" class="px-3 py-2 bg-gray-600 rounded text-white">Fermer</button>
+          <button  @click="$emit('close')" class="px-3 py-2 bg-gray-600 rounded text-white">Fermer</button>
         </div>
       </div>
     </div>
@@ -40,9 +36,11 @@ import ConfirmationModal from './ConfirmationModal.vue';
 export default defineComponent({
   name: 'SettingsModal',
   components: { ConfirmationModal },
-  setup() {
-    // Etat de visibilité de la modale
-    const isOpen = ref(false);
+  props: {
+    isOpen: { type: Boolean, required: true }
+  },
+  emits: ['close'],
+  setup(props, { emit }) {
     // Fichier sélectionné pour l'import
     const toImport = ref<File | null>(null);
 
@@ -70,13 +68,13 @@ export default defineComponent({
       if (toImport.value) {
         await importLibrary(toImport.value);
         toImport.value = null;
-        isOpen.value = false;
+        emit('close');
         window.location.reload();
       }
     }
 
     // Données et méthodes exposées au template
-    return { isOpen, toImport, triggerExport, onFileChange, confirmImport };
+    return { toImport, triggerExport, onFileChange, confirmImport };
   }
 });
 </script>

--- a/src/components/Uploader.vue
+++ b/src/components/Uploader.vue
@@ -1,5 +1,5 @@
 <template>
-    <label class="w-8 cursor-pointer bg-purple-500 hover:bg-purple-600 px-2 py-1
+    <label class="w-8 cursor-pointer bg-purple-600 hover:bg-purple-500 px-2 py-1
             rounded-lg flex items-center gap-2 transition-colors justify-center">
 
       <Plus/>

--- a/src/persistance/ImportExportService.ts
+++ b/src/persistance/ImportExportService.ts
@@ -1,0 +1,88 @@
+import JSZip from 'jszip';
+import { DB_GetPlaylists, DB_AddPlaylist } from './PlaylistService';
+import { DB_GetTracks, DB_AddTrack } from './TrackService';
+import { PlaylistLibraryDB } from './PlaylistPersistance';
+import { TrackLibraryDB } from './TrackPersistance';
+import Playlist from '@/models/Playlist';
+import FileTrack from '@/models/FileTrack';
+
+interface ExportTrackMeta {
+  name: string;
+  initialVolume: number;
+  iconName?: string;
+  iconColor?: string;
+  order: number;
+  playlistIndex: number;
+  loop?: boolean;
+  type: string;
+  filePath: string;
+}
+
+interface ExportData {
+  version: number;
+  playlists: { name: string; width?: number | null }[];
+  tracks: ExportTrackMeta[];
+}
+
+export async function exportLibrary(): Promise<Blob> {
+  const playlists = await DB_GetPlaylists();
+  const tracks = await DB_GetTracks();
+
+  const data: ExportData = {
+    version: 1,
+    playlists: playlists.map(pl => ({ name: pl.name, width: pl.width ?? null })),
+    tracks: [],
+  };
+
+  const zip = new JSZip();
+
+  for (const [idx, track] of tracks.entries()) {
+    const playlistIndex = playlists.findIndex(p => p.id === track.playlistId);
+    const path = `tracks/${idx}`;
+    zip.file(path, track.file);
+    data.tracks.push({
+      name: track.name,
+      initialVolume: track.initialVolume,
+      iconName: track.iconName,
+      iconColor: track.iconColor,
+      order: track.order,
+      playlistIndex,
+      loop: track.loop,
+      type: track.file.type,
+      filePath: path,
+    });
+  }
+
+  zip.file('data.json', JSON.stringify(data));
+  return zip.generateAsync({ type: 'blob' });
+}
+
+export async function importLibrary(blob: Blob): Promise<void> {
+  const zip = await JSZip.loadAsync(blob);
+  const json = await zip.file('data.json')!.async('string');
+  const data: ExportData = JSON.parse(json);
+
+  await PlaylistLibraryDB.playlists.clear();
+  await TrackLibraryDB.tracks.clear();
+
+  const playlists: Playlist[] = [];
+  for (const plData of data.playlists) {
+    const pl = new Playlist(plData.name);
+    pl.width = plData.width ?? undefined;
+    pl.id = await DB_AddPlaylist(pl);
+    playlists.push(pl);
+  }
+
+  for (const trackMeta of data.tracks) {
+    const trackBlob = await zip.file(trackMeta.filePath)!.async('blob');
+    const file = new File([trackBlob], trackMeta.name, { type: trackMeta.type });
+    const ft = new FileTrack(file, trackMeta.name);
+    ft.initialVolume = trackMeta.initialVolume ?? 0.8;
+    ft.iconName = trackMeta.iconName ?? '';
+    ft.iconColor = trackMeta.iconColor ?? '#c084fc';
+    ft.order = trackMeta.order ?? 0;
+    ft.playlistId = playlists[trackMeta.playlistIndex]?.id;
+    ft.loop = trackMeta.loop ?? false;
+    await DB_AddTrack(ft);
+  }
+}

--- a/src/persistance/ImportExportService.ts
+++ b/src/persistance/ImportExportService.ts
@@ -6,29 +6,44 @@ import { TrackLibraryDB } from './TrackPersistance';
 import Playlist from '@/models/Playlist';
 import FileTrack from '@/models/FileTrack';
 
+// Informations sur un morceau à sauvegarder dans l'archive
 interface ExportTrackMeta {
+  // Nom du fichier original
   name: string;
+  // Volume initial défini par l'utilisateur
   initialVolume: number;
+  // Options d'icône (facultatif)
   iconName?: string;
   iconColor?: string;
+  // Ordre dans la playlist
   order: number;
+  // Index de la playlist dans le tableau exporté
   playlistIndex: number;
+  // Indique si la boucle est active
   loop?: boolean;
+  // Mime type du fichier
   type: string;
+  // Chemin du fichier dans l'archive
   filePath: string;
 }
 
+// Structure globale du fichier d'export
 interface ExportData {
+  // Numéro de version pour la compatibilité future
   version: number;
+  // Liste des playlists enregistrées
   playlists: { name: string; width?: number | null }[];
+  // Liste des métadonnées de morceaux
   tracks: ExportTrackMeta[];
 }
 
+// Exporte la base de données complète dans une archive ZIP
 export async function exportLibrary(): Promise<Blob> {
   const playlists = await DB_GetPlaylists();
   const tracks = await DB_GetTracks();
 
   const data: ExportData = {
+    // incrémenter si le format change à l'avenir
     version: 1,
     playlists: playlists.map(pl => ({ name: pl.name, width: pl.width ?? null })),
     tracks: [],
@@ -36,10 +51,13 @@ export async function exportLibrary(): Promise<Blob> {
 
   const zip = new JSZip();
 
+  // Ajout des fichiers audio dans l'archive
   for (const [idx, track] of tracks.entries()) {
     const playlistIndex = playlists.findIndex(p => p.id === track.playlistId);
     const path = `tracks/${idx}`;
+    // on stocke le fichier brut dans un dossier "tracks"
     zip.file(path, track.file);
+    // on conserve les métadonnées pour la restauration
     data.tracks.push({
       name: track.name,
       initialVolume: track.initialVolume,
@@ -53,19 +71,23 @@ export async function exportLibrary(): Promise<Blob> {
     });
   }
 
+  // métadonnées globales stockées dans un JSON à la racine
   zip.file('data.json', JSON.stringify(data));
   return zip.generateAsync({ type: 'blob' });
 }
 
+// Importe l'archive produite par exportLibrary et remplace la base actuelle
 export async function importLibrary(blob: Blob): Promise<void> {
   const zip = await JSZip.loadAsync(blob);
   const json = await zip.file('data.json')!.async('string');
   const data: ExportData = JSON.parse(json);
 
+  // On vide la base existante avant d'insérer les nouvelles données
   await PlaylistLibraryDB.playlists.clear();
   await TrackLibraryDB.tracks.clear();
 
   const playlists: Playlist[] = [];
+  // Reconstruction des playlists
   for (const plData of data.playlists) {
     const pl = new Playlist(plData.name);
     pl.width = plData.width ?? undefined;
@@ -73,10 +95,12 @@ export async function importLibrary(blob: Blob): Promise<void> {
     playlists.push(pl);
   }
 
+  // Restauration des fichiers audio avec leurs métadonnées
   for (const trackMeta of data.tracks) {
     const trackBlob = await zip.file(trackMeta.filePath)!.async('blob');
     const file = new File([trackBlob], trackMeta.name, { type: trackMeta.type });
     const ft = new FileTrack(file, trackMeta.name);
+    // Valeurs par défaut pour assurer la compatibilité avec d'éventuelles nouvelles propriétés
     ft.initialVolume = trackMeta.initialVolume ?? 0.8;
     ft.iconName = trackMeta.iconName ?? '';
     ft.iconColor = trackMeta.iconColor ?? '#c084fc';


### PR DESCRIPTION
## Summary
- add JSZip dependency for file archive
- create ConfirmationModal and SettingsModal for UI
- implement import/export logic with ImportExportService
- integrate SettingsModal in Screen header

## Testing
- `npx eslint . --fix` *(fails: 30 errors)*
- `npm run build-no-icons`

------
https://chatgpt.com/codex/tasks/task_b_6856e8e99f5c8333ab69cdca29757c6c