### PR TITLE
Add external link playback feature

### DIFF
--- a/src/components/LibraryTrack.vue
+++ b/src/components/LibraryTrack.vue
@@ -42,6 +42,9 @@
         <Repeat1 v-if="trackFile.loop" class="w-5 h-5 text-purple-400" />
         <Repeat1 v-if="!trackFile.loop" class="w-5 h-5 text-gray-400" />
       </button>
+      <button class="p-1 rounded-full hover:bg-purple-400/20 transition-colors" @click="copyLink" :disabled="!trackFile.id">
+        <Link class="w-5 h-5 text-purple-300" />
+      </button>
       <button @click="onRemove" class="p-1 hover:bg-red-700/20 rounded-full transition-colors">
         <Trash2 class="w-5 h-5 text-red-400" />
       </button>
@@ -77,7 +80,7 @@
 
 <script lang="ts">
   import { defineComponent, defineAsyncComponent, ref, computed, nextTick } from 'vue';
-  import { GripVertical } from 'lucide-vue-next';
+  import { GripVertical, Link } from 'lucide-vue-next';
   import FileTrack from '@/models/FileTrack';
   import { DB_UpdateTrack } from '@/persistance/TrackService';
   import IconSelector from './IconSelector.vue';
@@ -89,6 +92,7 @@
     components: {
       IconSelector,
       GripVertical,
+      Link,
     },
     props: {
       trackFile: {
@@ -138,6 +142,13 @@
         emit('play', props.trackFile);
       }
 
+      function copyLink() {
+        if (!props.trackFile.id) return;
+        const url = new URL(window.location.href);
+        url.searchParams.set('trackId', String(props.trackFile.id));
+        navigator.clipboard.writeText(url.toString());
+      }
+
       async function onIconChosen(payload: { iconName: string; color: string }) {
         props.trackFile.iconName = payload.iconName;
         props.trackFile.iconColor = payload.color;
@@ -165,6 +176,7 @@
         handleVolumeChange,
         onRemove,
         onPlay,
+        copyLink,
         onIconChosen,
         onDragStart,
         spriteHref,

--- a/src/components/Screen.vue
+++ b/src/components/Screen.vue
@@ -1,5 +1,8 @@
 <template>
   <div class="min-h-screen bg-gray-900 grid" :class="isPlayerCollapsed ? 'grid-cols-[1fr_1.5rem]' : 'grid-cols-[1fr_24rem]'">
+    <div v-if="toastMessage" class="fixed top-2 left-1/2 -translate-x-1/2 bg-red-600 text-white px-3 py-2 rounded z-50">
+      {{ toastMessage }}
+    </div>
     <div class="p-8 overflow-auto min-w-[522px]">
       <div class="flex items-center justify-between">
         <h1 class="text-3xl font-bold text-purple-400 mb-8">MJ Screen Jukebox</h1>
@@ -22,7 +25,7 @@
 </template>
 
 <script lang="ts">
-  import { defineComponent, ref, watch } from 'vue';
+  import { defineComponent, ref, watch, onMounted } from 'vue';
   import Library from './Library.vue';
   import TracksPlayer from './TracksPlayer.vue';
   // Bouton ouvrant la modale d'import/export
@@ -31,6 +34,7 @@
   import CollapsibleSidebar from './CollapsibleSidebar.vue';
   import FileTrack from '../models/FileTrack'
   import { Cookies } from '../models/Cookies';
+  import { DB_GetTrack } from '@/persistance/TrackService';
 
   export default defineComponent({
     name: 'Screen',
@@ -44,6 +48,8 @@
       const library = ref<InstanceType<typeof Library> | null>(null);
       const tracksPlayer = ref<InstanceType<typeof TracksPlayer> | null>(null);
       const showSettings = ref(false)
+      const toastMessage = ref<string | null>(null)
+      const broadcast = new BroadcastChannel('mjscreen')
 
       const isPlayerCollapsed = ref(Cookies.get('playerCollapsed') === 'true');
       watch(isPlayerCollapsed, val => {
@@ -56,9 +62,57 @@
         }
       };
 
+      function showToast(msg: string) {
+        toastMessage.value = msg
+        setTimeout(() => (toastMessage.value = null), 3000)
+      }
+
+      async function playTrackById(id: number) {
+        const track = await DB_GetTrack(id)
+        if (track) {
+          handlePlay(track)
+        } else {
+          showToast('Track introuvable')
+        }
+      }
+
       const handleOpenSettings = () => {
         showSettings.value = true
       }
+
+      onMounted(() => {
+        broadcast.addEventListener('message', (e) => {
+          if (e.data?.type === 'open-track') {
+            playTrackById(Number(e.data.trackId))
+            broadcast.postMessage({ type: 'ack' })
+            window.focus()
+          }
+        })
+
+        const url = new URL(window.location.href)
+        const param = url.searchParams.get('trackId')
+        if (param) {
+          const id = Number(param)
+          let ack = false
+          const handler = (e: MessageEvent) => {
+            if (e.data?.type === 'ack') {
+              ack = true
+              broadcast.removeEventListener('message', handler)
+              window.close()
+            }
+          }
+          broadcast.addEventListener('message', handler)
+          broadcast.postMessage({ type: 'open-track', trackId: id })
+          setTimeout(() => {
+            broadcast.removeEventListener('message', handler)
+            if (!ack) {
+              playTrackById(id)
+            }
+            url.searchParams.delete('trackId')
+            window.history.replaceState({}, '', url.toString())
+          }, 200)
+        }
+      })
 
       return {
         library,
@@ -67,6 +121,7 @@
         isPlayerCollapsed,
         handleOpenSettings,
         showSettings,
+        toastMessage,
       };
     },
   });

--- a/src/persistance/TrackService.ts
+++ b/src/persistance/TrackService.ts
@@ -85,3 +85,22 @@ export async function DB_GetTracks(): Promise<FileTrack[]> {
   // 3) Retourne la liste des FileTrack
   return fileTracks;
 }
+
+/**
+ * Retrieve a single track by its id from Dexie
+ */
+export async function DB_GetTrack(id: number): Promise<FileTrack | undefined> {
+  const st = await TrackLibraryDB.tracks.get(id);
+  if (!st) return undefined;
+
+  const file = new File([st.blob], st.name, { type: st.blob.type });
+  const ft = new FileTrack(file, st.name);
+  ft.initialVolume = st.initialVolume;
+  ft.id = st.id;
+  ft.iconName = st.iconName;
+  ft.iconColor = st.iconColor ?? '#c084fc';
+  ft.order = st.order;
+  ft.playlistId = st.playlistId;
+  ft.loop = st.loop ?? false;
+  return ft;
+}


### PR DESCRIPTION
## Summary
- add single-track DB retrieval helper
- allow copy of a track link from the library
- open tracks from `?trackId=` URL via BroadcastChannel and close the extra tab
- display a simple toast message on error

## Testing
- `npm run type-check` *(fails: vue-tsc not found)*
- `npm run lint` *(fails: eslint-plugin-vue missing)*

------
https://chatgpt.com/codex/tasks/task_b_685fe5bf54a88333bafb8c9685cf714f